### PR TITLE
Syntax highlight the current line

### DIFF
--- a/colors/bubblegum-256-dark.vim
+++ b/colors/bubblegum-256-dark.vim
@@ -99,7 +99,7 @@ hi MatchParen ctermfg=16 ctermbg=215 cterm=none guifg=#000000 guibg=#FFAF5F gui=
 
 " Cursor
 hi CursorColumn ctermfg=249 ctermbg=237 cterm=none guifg=#B2B2B2 guibg=#3A3A3A gui=none
-hi CursorLine ctermfg=249 ctermbg=237 cterm=none guifg=#B2B2B2 guibg=#3A3A3A gui=none
+hi CursorLine ctermbg=237 cterm=none guibg=#3A3A3A gui=none
 hi CursorLineNr ctermfg=249 ctermbg=237 cterm=none guifg=#B2B2B2 guibg=#3A3A3A gui=none
 
 " Search

--- a/colors/bubblegum-256-light.vim
+++ b/colors/bubblegum-256-light.vim
@@ -99,7 +99,7 @@ hi MatchParen ctermfg=231 ctermbg=166 cterm=none guifg=#FFFFFF guibg=#D75F00 gui
 
 " Cursor
 hi CursorColumn ctermfg=241 ctermbg=254 cterm=none guifg=#626262 guibg=#E4E4E4 gui=none
-hi CursorLine ctermfg=241 ctermbg=254 cterm=none guifg=#626262 guibg=#E4E4E4 gui=none
+hi CursorLine ctermbg=254 cterm=none guibg=#E4E4E4 gui=none
 hi CursorLineNr ctermfg=241 ctermbg=254 cterm=none guifg=#626262 guibg=#E4E4E4 gui=none
 
 " Search


### PR DESCRIPTION
Current version removes all colors from the current line, fixed by not specifying a foreground color for the cursorline.

If this was intentional please ignore.
